### PR TITLE
Fix SHA256 sum for Fossil 2.10

### DIFF
--- a/fossil/tools/chocolateyInstall.ps1
+++ b/fossil/tools/chocolateyInstall.ps1
@@ -2,7 +2,7 @@
 
 $packageName = 'fossil'
 $url64 = 'https://www.fossil-scm.org/home/uv/fossil-w64-2.10.zip'
-$checksum64 = '86c88d48fc78ae2276bb5a71dcb1657d58743a0557a5eecda8210372139b7d24'
+$checksum64 = '986A44B483721F4F225EBD6574D98BA4C4EF5E467DD3BB303C0D48707EE1966E'
 $checksumType64 = 'sha256'
 $toolsDir = "$(Split-Path -Parent $MyInvocation.MyCommand.Definition)"
 


### PR DESCRIPTION
Version 2.10 has the wrong sha2526 hash.
```
Error - hashes do not match. Actual value was '986A44B483721F4F225EBD6574D98BA4C4EF5E467DD3BB303C0D48707EE1966E'.
ERROR: Checksum for 'C:\Users\jpdasma\AppData\Local\Temp\chocolatey\fossil\2.10\fossil-w64-2.10.zip' did not meet '86c88d48fc78ae2276bb5a71dcb1657d58743a0557a5eecda8210372139b7d24' for checksum type 'sha256'. Consider passing the actual checksums through with --checksum --checksum64 once you validate the checksums are appropriate. A less secure option is to pass --ignore-checksums if necessary.
The upgrade of fossil was NOT successful.
```

```
$  Invoke-WebRequest -Uri https://www.fossil-scm.org/home/uv/fossil-w64-2.10.zip -OutFile fossil-w64-2.10.zip               
$  (Get-FileHash -Algorithm SHA256 .\fossil-w64-2.10.zip).Hash
986A44B483721F4F225EBD6574D98BA4C4EF5E467DD3BB303C0D48707EE1966E
```